### PR TITLE
Added support for "Product Delivery Date for WooCommerce - Lite"

### DIFF
--- a/classes/Academe_Multiple_Packages.php
+++ b/classes/Academe_Multiple_Packages.php
@@ -313,7 +313,7 @@ class Academe_Multiple_Packages
 
                         $product_id = $item['product_id'];
 
-                        $meta_value = $item[$meta_field_name];
+                        $meta_value = serialize($item[$meta_field_name]);
 				
                         $package_meta['package_grouping_value'] = $meta_value;
 


### PR DESCRIPTION
Using serialize() on the order item meta value gives support to non-scalar value.

For example, with this version we support the free plugin "Product Delivery Date for WooCommerce - Lite". Simply specifying 'prdd_delivery' in the "Custom Field to Group By" field in plugin Settings allow you to group by delivery dates :)

http://snag.gy/ONN8Y.jpg
